### PR TITLE
Implement weekly, monthly and yearly karma query

### DIFF
--- a/karmagrambot/analytics.py
+++ b/karmagrambot/analytics.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Dict, List
+from typing import Dict, List, Optional
 from datetime import date
 import dataset
 
@@ -31,7 +31,7 @@ def average_message_length(user_id: int, chat_id: int) -> float:
     return sum(m['length'] for m in messages) / len(messages)
 
 
-def get_karma(user_id: int, chat_id: int, period: date = None) -> int:
+def get_karma(user_id: int, chat_id: int, period: Optional[date] = None) -> int:
     """Get the karma of an given user in a given chat.
 
     Args:
@@ -54,7 +54,7 @@ def get_karma(user_id: int, chat_id: int, period: date = None) -> int:
     return votes['+'] - votes['-']
 
 
-def get_top_n_karmas(chat_id: int, n: int, period: date = None) -> List[UserKarma]:
+def get_top_n_karmas(chat_id: int, n: int, period: Optional[date] = None) -> List[UserKarma]:
     """Get the top n karmas in a given group, if the doesn't have enough users, return the total amount.
     Args:
         chat_id: The id of the chat that we're interested in.

--- a/karmagrambot/commands.py
+++ b/karmagrambot/commands.py
@@ -61,10 +61,8 @@ def karma(_: Bot, update: Update):
 
     user_karma = analytics.get_karma(user_info.user_id, message.chat_id, period)
 
-    reply_msg = f'{user_info.username} has {user_karma} karma in this chat'
-    reply_msg += f' (since {period}).' if period is not None else f' (all time).'
-
-    message.reply_text(reply_msg)
+    period_suffix = f'(since {period})' if period is not None else f'(all time)'
+    message.reply_text(f'{user_info.username} has {user_karma} karma in this chat {period_suffix}.')
 
 
 def karmas(_: Bot, update: Update):
@@ -79,10 +77,13 @@ def karmas(_: Bot, update: Update):
     """
     text = update.message.text
     _, *args = text.split()
-    arg = args[0].lstrip('-') if args else None
-    period = get_period('m')
-    if arg in ('w', 'week', 'y', 'year', 'all', 'alltime'):
-        period = get_period(arg)
+    arg = args[0] if args else 'm'
+    requested_period = arg.lstrip('-')
+    if requested_period not in ('m', 'month', 'w', 'week', 'y', 'year', 'all', 'alltime'):
+        update.message.reply_text(f'Period {requested_period} is not supported.')
+        return
+
+    period = get_period(arg)
 
     top_users = analytics.get_top_n_karmas(update.message.chat.id, 10, period)
 

--- a/karmagrambot/commands.py
+++ b/karmagrambot/commands.py
@@ -6,7 +6,7 @@ import dataset
 
 from . import analytics
 from .config import DB_URI
-from .util import user_info_from_message_or_reply, user_info_from_username
+from .util import user_info_from_message_or_reply, user_info_from_username, get_period
 
 
 def average_length(_: Bot, update: Update):
@@ -39,7 +39,15 @@ def karma(_: Bot, update: Update):
 
     _, *args = text.split()
 
-    username = args[0].lstrip('@') if args else None
+    username = None
+    period = get_period('m')
+    if args:
+        for arg in args:
+            arg = arg.lstrip('-')
+            if arg in ('w', 'week', 'y', 'year', 'all', 'alltime'):
+                period = get_period(arg)
+            elif arg != 'm':
+                username = arg.lstrip('@')
 
     user_info = (
         user_info_from_message_or_reply(message)
@@ -51,9 +59,12 @@ def karma(_: Bot, update: Update):
         message.reply_text(f'Could not find user named {username}')
         return
 
-    user_karma = analytics.get_karma(user_info.user_id, message.chat_id)
+    user_karma = analytics.get_karma(user_info.user_id, message.chat_id, period)
 
-    message.reply_text(f'{user_info.username} has {user_karma} karma in this chat')
+    reply_msg = f'{user_info.username} has {user_karma} karma in this chat'
+    reply_msg += f' (since {period}).' if period is not None else f' (all time).'
+
+    message.reply_text(reply_msg)
 
 
 def karmas(_: Bot, update: Update):
@@ -66,7 +77,14 @@ def karmas(_: Bot, update: Update):
         bot: The object that represents the Telegram Bot.
         update: The object that represents an incoming update for the bot to handle.
     """
-    top_users = analytics.get_top_n_karmas(update.message.chat.id, 10)
+    text = update.message.text
+    _, *args = text.split()
+    arg = args[0].lstrip('-') if args else None
+    period = get_period('m')
+    if arg in ('w', 'week', 'y', 'year', 'all', 'alltime'):
+        period = get_period(arg)
+
+    top_users = analytics.get_top_n_karmas(update.message.chat.id, 10, period)
 
     response = '\n'.join(
         f'{i} - {user.name} ({user.karma})' for i, user in enumerate(top_users, 1)

--- a/karmagrambot/util.py
+++ b/karmagrambot/util.py
@@ -1,5 +1,6 @@
 """Utility module."""
 from typing import NamedTuple, Optional
+from datetime import date
 
 from telegram import Message
 
@@ -52,3 +53,20 @@ def user_info_from_username(db, username) -> Optional[UserInfo]:
     user_id = user['user_id']
 
     return UserInfo(user_id, username)
+
+
+def get_period(arg_period: str) -> Optional[date]:
+    today = date.today()
+    if arg_period == 'm':
+        timestamp = today.replace(day=1)
+    elif arg_period in ('y', 'year'):
+        timestamp = today.replace(day=1, month=1)
+    elif arg_period in ('w', 'week'):
+        from calendar import monthrange
+        last_month = today.month
+        days_last_month = monthrange(today.year, today.month)[1]
+        timestamp = today.replace(day=(today.day-7)%days_last_month, month=last_month)
+    else:
+        return None
+    
+    return timestamp

--- a/karmagrambot/util.py
+++ b/karmagrambot/util.py
@@ -1,6 +1,7 @@
 """Utility module."""
 from typing import NamedTuple, Optional
 from datetime import date
+from calendar import monthrange
 
 from telegram import Message
 
@@ -57,12 +58,11 @@ def user_info_from_username(db, username) -> Optional[UserInfo]:
 
 def get_period(arg_period: str) -> Optional[date]:
     today = date.today()
-    if arg_period == 'm':
+    if arg_period in ('m', 'month'):
         timestamp = today.replace(day=1)
     elif arg_period in ('y', 'year'):
         timestamp = today.replace(day=1, month=1)
     elif arg_period in ('w', 'week'):
-        from calendar import monthrange
         last_month = today.month
         days_last_month = monthrange(today.year, today.month)[1]
         timestamp = today.replace(day=(today.day-7)%days_last_month, month=last_month)


### PR DESCRIPTION
Add bot commands:
`/karma w [username]` (weekly result)
`/karma m [username]` (monthly result)
`/karma y [username]` (year/annual result)
`/karma all [username]` (all-time result)
Also works with flags (e.g. -w), and full option names (e.g. -week).