### PR TITLE
Add isort to organize includes 

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,3 @@
+[settings]
+profile=hug
+line_length=100 

--- a/karmagrambot/analytics.py
+++ b/karmagrambot/analytics.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
-from typing import Dict, List, Optional
 from datetime import date
+from typing import Dict, List, Optional
+
 import dataset
 
 from .config import DB_URI

--- a/karmagrambot/commands.py
+++ b/karmagrambot/commands.py
@@ -1,12 +1,11 @@
 """Aggregate every user-available command."""
+import dataset
 from telegram import Bot, Update
 from telegram.ext import CommandHandler
 
-import dataset
-
 from . import analytics
 from .config import DB_URI
-from .util import user_info_from_message_or_reply, user_info_from_username, get_period
+from .util import get_period, user_info_from_message_or_reply, user_info_from_username
 
 
 def average_length(_: Bot, update: Update):

--- a/karmagrambot/util.py
+++ b/karmagrambot/util.py
@@ -1,7 +1,7 @@
 """Utility module."""
-from typing import NamedTuple, Optional
-from datetime import date
 from calendar import monthrange
+from datetime import date
+from typing import NamedTuple, Optional
 
 from telegram import Message
 


### PR DESCRIPTION
isort is a Python utility / library to sort imports alphabetically, and automatically separated into sections and by type. It provides a command line utility, Python library and plugins for various editors to quickly sort all imports.